### PR TITLE
168815793 - Remover campos Base e Reator do cadastro de Materiais

### DIFF
--- a/app/DataTables/MaterialDataTable.php
+++ b/app/DataTables/MaterialDataTable.php
@@ -72,9 +72,7 @@ class MaterialDataTable extends DataTable
             'nome',
             'tipoMaterialNome' => ['data' => 'tipoMaterialNome', 'title' => 'Tipo de Material', 'searchable' => false],
             'potenciaValor' => ['data' => 'potenciaValor', 'title' => 'Potência', 'searchable' => false],
-            'tensaoValor' => ['data' => 'tensaoValor', 'title' => 'Potência', 'searchable' => false],
-            'reatorNome' => ['data' => 'reatorNome', 'title' => 'Reator', 'searchable' => false],
-            'receptaculoNome' => ['data' => 'receptaculoNome', 'title' => 'Receptáculo', 'searchable' => false],
+            'tensaoValor' => ['data' => 'tensaoValor', 'title' => 'Potência', 'searchable' => false],            
         ];
     }
 

--- a/app/Models/Material.php
+++ b/app/Models/Material.php
@@ -27,14 +27,10 @@ class Material extends Model
         'nome',
         'potencia_id',
         'tensao_id',
-        'tipo_material_id',
-        'reator_id',
-        'receptaculo_id',
+        'tipo_material_id',        
     ];
 
-    public $appends = [
-        'receptaculoNome',
-        'reatorNome',
+    public $appends = [        
         'tipoMaterialNome',
         'potenciaValor',
         'tensaoValor',
@@ -50,9 +46,7 @@ class Material extends Model
         'nome' => 'string',
         'potencia' => 'string',
         'tensao' => 'string',
-        'tipo_material_id' => 'integer',
-        'reator_id'  => 'integer',
-        'receptaculo_id'  => 'integer',
+        'tipo_material_id' => 'integer',        
         'potencia_id'  => 'integer',
         'tensao_id'  => 'integer',
     ];
@@ -73,22 +67,7 @@ class Material extends Model
     {
         return $this->belongsTo(\App\Models\TipoMaterial::class, 'tipo_material_id');
     }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     **/
-    public function reator()
-    {
-        return $this->belongsTo(self::class, 'reator_id');
-    }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     **/
-    public function receptaculo()
-    {
-        return $this->belongsTo(self::class, 'receptaculo_id');
-    }
+    
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
@@ -116,31 +95,7 @@ class Material extends Model
         if ($this->tipoMaterial()->exists()) {
             return $this->tipoMaterial->nome;
         }
-    }
-
-    /**
-     * Acessor para a informação de Reator.
-     *
-     * @return int
-     */
-    public function getReatorNomeAttribute()
-    {
-        if ($this->reator()->exists()) {
-            return $this->reator->nome;
-        }
-    }
-
-    /**
-     * Acessor para a informação de Receptaculo.
-     *
-     * @return int
-     */
-    public function getReceptaculoNomeAttribute()
-    {
-        if ($this->receptaculo()->exists()) {
-            return $this->receptaculo->nome;
-        }
-    }
+    }    
 
     /**
      * Acessor para a informação de Potencia.

--- a/database/migrations/2019_09_10_161138_create_materiais_table.php
+++ b/database/migrations/2019_09_10_161138_create_materiais_table.php
@@ -15,16 +15,12 @@ class CreateMateriaisTable extends Migration
         Schema::create('materiais', function (Blueprint $table) {
             $table->bigInteger('id', true);
             $table->string('nome')->nullable();
-            $table->integer('tipo_material_id')->unsigned()->nullable();
-            $table->integer('reator_id')->unsigned()->nullable();
-            $table->integer('receptaculo_id')->unsigned()->nullable();
+            $table->integer('tipo_material_id')->unsigned()->nullable();            
             $table->integer('potencia_id')->unsigned()->nullable();
             $table->integer('tensao_id')->unsigned()->nullable();
             $table->timestamps();
             $table->softDeletes();
-            $table->foreign('tipo_material_id')->references('id')->on('tipos_materiais');
-            $table->foreign('reator_id')->references('id')->on('materiais');
-            $table->foreign('receptaculo_id')->references('id')->on('materiais');
+            $table->foreign('tipo_material_id')->references('id')->on('tipos_materiais');            
             $table->foreign('potencia_id')->references('id')->on('potencias');
             $table->foreign('tensao_id')->references('id')->on('tensoes');
         });

--- a/resources/views/materiais/fields.blade.php
+++ b/resources/views/materiais/fields.blade.php
@@ -6,19 +6,7 @@
         @include('tipos_materiais.select', [
             'Model' => $material
         ])
-    </div>
-    
-    <div class="form-group col-sm-6">
-        @include('materiais.select_reatores', [
-            'Model' => $material
-        ])
-    </div>
-
-    <div class="form-group col-sm-6">
-        @include('materiais.select_receptaculos', [
-            'Model' => $material
-        ])
-    </div>
+    </div>    
 
     <div class="form-group col-sm-6">
         @include('potencias.select', [


### PR DESCRIPTION
Precisei remover essas colunas pois a modelagem está errada.
Discutimos na homologação com o Thiago, e entendemos que essa associação não precisa acontecer.
A associação correspondente deve acontecer ao associar Item e Material. Não precisamos saber que determinada lâmpada está conectada a um reator ou base específica, e sim que esses 3 materiais estão associados a um determinado item, com quantidade X.