### PR TITLE
WebAdmin | Validação no cadastro de Materiais

### DIFF
--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -6,6 +6,7 @@
     "/js/pages/Cidades.js": "/js/pages/Cidades.js",
     "/js/pages/EntradaMateriais.js": "/js/pages/EntradaMateriais.js",
     "/js/pages/Estoque.js": "/js/pages/Estoque.js",
+    "/js/pages/Materiais.js": "/js/pages/Materiais.js",
     "/js/pages/MateriaisItem.js": "/js/pages/MateriaisItem.js",
     "/js/pages/Plantas.js": "/js/pages/Plantas.js",
     "/js/pages/QuantidadesMinimas.js": "/js/pages/QuantidadesMinimas.js",

--- a/resources/js/pages/Materiais.js
+++ b/resources/js/pages/Materiais.js
@@ -1,0 +1,26 @@
+/**
+ * @class Materiais
+ */
+class Materiais {
+
+  /**
+   * @constructor
+   */
+  constructor() {
+    this.eventHandlers()
+  }
+
+  /**
+   * @returns
+   */
+  eventHandlers() {
+    $('.tipoMaterial').on('change', async event => {
+      const id = event.currentTarget.value;
+
+      $('.nomeMaterial').prop('disabled', id.length > 0).prop('value', null);
+    })
+  }
+
+}
+
+new Materiais

--- a/resources/views/materiais/fields.blade.php
+++ b/resources/views/materiais/fields.blade.php
@@ -59,7 +59,7 @@
 <!-- Nome Field -->
 <div class="form-group col-sm-6">
     {!! Form::label('nome', 'Nome') !!}
-    {!! Form::text('nome', null, ['class' => 'form-control']) !!}
+    {!! Form::text('nome', null, ['class' => 'form-control nomeMaterial']) !!}
 </div>
 
 <!-- Submit Field -->
@@ -67,3 +67,7 @@
     {!! Form::submit('Salvar', ['class' => 'btn btn-primary']) !!}
     <a href="{!! route('materiais.index') !!}" class="btn btn-default">Cancelar</a>
 </div>
+
+@section('scripts')
+    <script src="/js/pages/Materiais.js"></script>
+@endsection

--- a/resources/views/tipos_materiais/select.blade.php
+++ b/resources/views/tipos_materiais/select.blade.php
@@ -5,7 +5,7 @@
 <!-- Select de empresas  -->
 <div class="form-group">
     {!! Form::label('tipos_materiais', 'Tipo de Material') !!} <br>
-    {!! Form::select('tipo_material_id', $tipos_materiais, $Model->tipoMaterial->id, ['class' => 'form-control select2']
+    {!! Form::select('tipo_material_id', $tipos_materiais, $Model->tipoMaterial->id, ['class' => 'form-control tipoMaterial select2']
     ) !!}
 </div>
 
@@ -14,7 +14,7 @@
 <!-- Select de empresas  -->
 <div class="form-group">
     {!! Form::label('tipos_materiais', 'Tipo de Material') !!} <br>
-    {!! Form::select('tipo_material_id', [''=>'']+$tipos_materiais, null, ['class' => 'form-control select2']
+    {!! Form::select('tipo_material_id', [''=>'']+$tipos_materiais, null, ['class' => 'form-control tipoMaterial select2']
     ) !!}
 </div>
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -10,6 +10,7 @@ mix
   .js('resources/js/pages/EntradaMateriais.js', 'public/js/pages')
   .js('resources/js/pages/QuantidadesMinimas.js', 'public/js/pages')
   .js('resources/js/pages/QuantidadesSubstituidas.js', 'public/js/pages')
+  .js('resources/js/pages/Materiais.js', 'public/js/pages')
 
   .sass('resources/sass/app.scss', 'public/css')
   .sass('resources/sass/pages/login.scss', 'public/css/pages')


### PR DESCRIPTION
Fiz um JS simples pra que quando o Tipo de Material for diferente de Base, o campo Nome deve estar desabilitado. Isso permite uma melhor usabilidade, pois quando o Material possui um Tipo de Material associado, o campo Nome é redundante. O campo Nome só é usado quando o material for do tipo Base, pois ele não é associado a nenhum Tipo de Material.