### PR TITLE
Devops | Exportar pra PDF parou de funcionar

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ v y
 v y watch
 ```
 
+Em caso de erros, executar:
+``` sh
+v down
+docker image rm vessel/app
+docker image rm vessel/node
+v start
+```
+
 ### Comando para gerar um CRUD
 
 - Criar arquivo na pasta `database/model_schemas` referente a entidade desejada;

--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ cp .env.example .env
 v start
 v comp i
 v art key:generate
-v art migrate
-v art passport:install
-
+v art migrate:fresh --seed
+v art passport:install --force
 v y
 v y watch
 ```

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -12,13 +12,14 @@ RUN useradd -ms /bin/bash -u 1337 vessel \
   && echo "deb http://ppa.launchpad.net/nginx/development/ubuntu bionic main" \
     > /etc/apt/sources.list.d/ppa_nginx_mainline.list \
   && export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C \
   && apt-get update
 
 RUN apt-get install -y --no-install-recommends \
     curl \
     libssl1.0-dev \
+    libxrender1 \
     nginx \
     supervisor \
     unzip \


### PR DESCRIPTION
Correção no Snappy PDF que tinha parado de funcionar em todos os ambientes. No ambiente de desenvolvimento, foi necessário instalar libs adicionais no Docker. Na stage, a mesma lib foi instalada globalmente, e na production algumas libs extras foram instaladas. Todos ambientes funcionando corretamente.

Para realizar testes e também após o ticket ser aceito, será necessário recriar o container `app`:

``` sh
v down
docker image rm vessel/app
v build
v start
```

- Removido estranho arquivo core
- Instalação do libxrender1
- Pequenas refatorações e melhorias